### PR TITLE
implement pull-down refresh and other changes

### DIFF
--- a/src/app/conference/index.tsx
+++ b/src/app/conference/index.tsx
@@ -4,7 +4,7 @@ import { List } from "react-native-paper";
 
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 
-import { RemoveConferencesContext } from "../../contexts/conferences";
+import { RefreshConferencexContext } from "../../contexts/conferences";
 import { conferenceCollection } from "../../database";
 import { Conference, Document } from "../../models";
 
@@ -13,7 +13,7 @@ import { RootStackParamList } from "..";
 type Props = NativeStackScreenProps<RootStackParamList, "ViewConference">;
 
 export default function ViewConference({ navigation, route }: Props) {
-  const removeConferences = useContext(RemoveConferencesContext);
+  const refreshConferences = useContext(RefreshConferencexContext);
   const [conference, setConference] = useState<Document<Conference>>(
     route.params.conference,
   );
@@ -24,10 +24,10 @@ export default function ViewConference({ navigation, route }: Props) {
         const data = doc.data();
         if (data === undefined) {
           navigation.goBack();
-          removeConferences([doc.id]);
         } else {
           setConference({ id: doc.id, data: data });
         }
+        refreshConferences();
       },
     });
   }, [conference.id]);

--- a/src/app/home.tsx
+++ b/src/app/home.tsx
@@ -1,10 +1,13 @@
-import { useContext, useLayoutEffect, useMemo } from "react";
+import { useContext, useLayoutEffect, useMemo, useState } from "react";
 import { FlatList } from "react-native";
 import { List, useTheme } from "react-native-paper";
 
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 
-import { ConferencesContext } from "../contexts/conferences";
+import {
+  ConferencesContext,
+  RefreshConferencexContext,
+} from "../contexts/conferences";
 
 import { RootStackParamList } from ".";
 
@@ -13,6 +16,8 @@ type Props = NativeStackScreenProps<RootStackParamList, "Home">;
 export default function Home({ navigation }: Props) {
   const theme = useTheme();
   const conferences = useContext(ConferencesContext);
+  const refreshConferences = useContext(RefreshConferencexContext);
+  const [refreshing, setRefreshing] = useState(false);
 
   const listItems = useMemo(() => {
     let items = [
@@ -26,7 +31,7 @@ export default function Home({ navigation }: Props) {
       />,
     ];
     items.push(
-      ...[...conferences.values()].map((item) => {
+      ...conferences.map((item) => {
         return (
           <List.Item
             title={item.data.title}
@@ -53,6 +58,11 @@ export default function Home({ navigation }: Props) {
       contentInsetAdjustmentBehavior="automatic"
       data={listItems}
       renderItem={(item) => item.item}
+      refreshing={refreshing}
+      onRefresh={() => {
+        setRefreshing(true);
+        refreshConferences().then(() => setRefreshing(false));
+      }}
     />
   );
 }

--- a/src/app/new/join.tsx
+++ b/src/app/new/join.tsx
@@ -8,15 +8,14 @@ import { ParamListBase } from "@react-navigation/native";
 import { ConfKeyTextInput } from "../../components";
 import HiddenHelperText from "../../components/HiddenHelperText";
 import {
-  AddConferencesContext,
   ConferencesContext,
+  RefreshConferencexContext,
 } from "../../contexts/conferences";
 import { conferenceCollection } from "../../database";
 
 type Props = MaterialTopTabScreenProps<ParamListBase>;
 
 export default function JoinConference({ navigation }: Props) {
-  const addConferences = useContext(AddConferencesContext);
   const conferences = useContext(ConferencesContext);
   const [err, setErr] = useState("");
 
@@ -27,7 +26,7 @@ export default function JoinConference({ navigation }: Props) {
   };
 
   function submit() {
-    const cached = conferences.get(keyInp);
+    const cached = conferences.find((value) => value.id == keyInp);
     if (cached !== undefined) {
       navigation.goBack();
       navigation.navigate("ViewConference", { conference: cached });
@@ -44,7 +43,6 @@ export default function JoinConference({ navigation }: Props) {
             return setErr("missing");
           default:
             const doc = { id: conf.id, data: data };
-            addConferences([doc]);
             navigation.goBack();
             navigation.navigate("ViewConference", { conference: doc });
         }


### PR DESCRIPTION
closes #20 

 - Pull down to refresh from cache
 - Use array instead of map to store conferences
 - Replace `addConferences` and `removeConferences` in favor of `refreshConferences`
 - Sort conferences by start date (in ascending order)